### PR TITLE
Add support for Contact Groups

### DIFF
--- a/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperAPIParams.ps1
+++ b/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperAPIParams.ps1
@@ -46,7 +46,7 @@ function ConvertTo-StatusCakeHelperAPIParams
                     $value = $var.value -join ","
                     $outputHashTable.Add($var.name,$value)                                                   
                 } 
-                "Mobile"{ #Mopbile numbers need to be supplied as a comma separated list
+                "Mobile"{ #Mobile numbers need to be supplied as a comma separated list
                     $value = $var.value -join ","
                     $outputHashTable.Add($var.name,$value)                                        
                 }                                  

--- a/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperDomainName.ps1
+++ b/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperDomainName.ps1
@@ -1,0 +1,28 @@
+
+<#
+.Synopsis
+   Converts a string parameter to a domain name
+.EXAMPLE
+   ConvertTo-StatusCakeHelperAPIParams -InputString [string]
+.INPUTS
+    InputString - String containing the value to convert to a domain name
+.FUNCTIONALITY
+   Converts a string parameters to a domain name.
+#>
+function ConvertTo-StatusCakeHelperDomainName
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$True,
+        ValueFromPipeline=$True)]        
+        [string] $InputString
+    ) 
+
+    if($InputString -match '^((http|https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$')
+    {
+        $InputString -match '(?<DomainName>([a-zA-Z0-9\-]{2,}\.[a-zA-Z\-]{2,})(\.[a-zA-Z\-]{2,})?(\.[a-zA-Z\-]{2,})?)' | Out-Null                
+        $InputString = $matches.DomainName
+    }
+
+    Return $InputString
+}

--- a/StatusCake-Helpers/Private/Test-StatusCakeHelperEmailAddress.ps1
+++ b/StatusCake-Helpers/Private/Test-StatusCakeHelperEmailAddress.ps1
@@ -1,0 +1,29 @@
+
+<#
+.Synopsis
+   Tests to confirm that a supplied email address is valid
+.EXAMPLE
+   Test-StatusCakeHelperEmailAddress "test@example.com"
+.INPUTS
+    Email - String containing email address
+.OUTPUTS    
+    Returns true if email address is valid
+.FUNCTIONALITY
+   Tests to confirm that a supplied email address is valid
+   
+#>
+function Test-StatusCakeHelperEmailAddress
+{
+    [CmdletBinding(PositionalBinding=$false)]    
+    Param(
+        [Parameter(Mandatory=$True,
+        ValueFromPipeline=$True)]
+        [string] $EmailAddress
+    )
+
+    if($EmailAddress -match '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+    {
+        Return $true
+    }
+    Return $false
+}

--- a/StatusCake-Helpers/Private/Test-StatusCakeHelperMobileNumber.ps1
+++ b/StatusCake-Helpers/Private/Test-StatusCakeHelperMobileNumber.ps1
@@ -1,0 +1,29 @@
+
+<#
+.Synopsis
+   Tests to confirm that a supplied mobile number is valid
+.EXAMPLE
+   Test-StatusCakeHelperMobileNo "test@example.com"
+.INPUTS
+    MobileNumber - String containing mobile number
+.OUTPUTS    
+    Returns true if mobile number is valid
+.FUNCTIONALITY
+   Tests to confirm that a supplied mobile number meets the E.164 number formatting
+   
+#>
+function Test-StatusCakeHelperMobileNumber
+{
+    [CmdletBinding(PositionalBinding=$false)]    
+    Param(
+        [Parameter(Mandatory=$True,
+        ValueFromPipeline=$True)]
+        [string] $MobileNumber
+    )
+
+    if($MobileNumber -match '^\+[1-9]{1}[0-9]{9,14}$')
+    {
+        Return $true
+    }
+    Return $false
+}

--- a/StatusCake-Helpers/Private/Test-StatusCakeHelperNodeLocation.ps1
+++ b/StatusCake-Helpers/Private/Test-StatusCakeHelperNodeLocation.ps1
@@ -1,0 +1,31 @@
+
+<#
+.Synopsis
+   Tests to confirm that a supplied node location is valid
+.EXAMPLE
+   Test-StatusCakeHelperNodeLocation [string]
+.INPUTS
+    NodeLocations - String containing the node location server code
+.OUTPUTS    
+    Returns true if node location server code is valid
+.FUNCTIONALITY
+   Tests to confirm that a supplied node location server code is valid
+   
+#>
+function Test-StatusCakeHelperNodeLocation
+{
+    [CmdletBinding(PositionalBinding=$false)]    
+    Param(
+        [Parameter(Mandatory=$True,
+        ValueFromPipeline=$True)]
+        [string] $NodeLocation
+    )
+
+    $StatusCakeServerCodes = (Get-StatusCakeHelperProbes).servercode
+
+    if($StatusCakeServerCodes -contains $NodeLocation)
+    {
+        Return $true
+    }
+    Return $false
+}

--- a/StatusCake-Helpers/Public/Get-StatusCakeHelperAllContactGroups.ps1
+++ b/StatusCake-Helpers/Public/Get-StatusCakeHelperAllContactGroups.ps1
@@ -1,0 +1,39 @@
+
+<#
+.Synopsis
+   Gets all the StatusCake Contact Groups
+.EXAMPLE
+   Get-StatusCakeHelperAllContactGroups
+.INPUTS
+    baseContactGroupURL - Base URL endpoint of the statuscake auth API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+.OUTPUTS    
+    Returns all the StatusCake ContactGroups as an object
+.FUNCTIONALITY
+    Retrieves all the contact groups from StatusCake
+   
+#>
+function Get-StatusCakeHelperAllContactGroups
+{
+    [CmdletBinding(PositionalBinding=$false)]    
+    Param(
+        $baseContactGroups = "https://app.statuscake.com/API/ContactGroups/",
+        [Parameter(Mandatory=$true)]        
+        $Username,
+        [Parameter(Mandatory=$true)]        
+        $ApiKey
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+
+    $requestParams = @{
+        uri = $baseContactGroups
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+    }
+
+    $jsonResponse = Invoke-WebRequest @requestParams
+    $response = $jsonResponse | ConvertFrom-Json
+    Return $response
+}
+

--- a/StatusCake-Helpers/Public/Get-StatusCakeHelperContactGroup.ps1
+++ b/StatusCake-Helpers/Public/Get-StatusCakeHelperContactGroup.ps1
@@ -1,0 +1,61 @@
+
+<#
+.Synopsis
+   Retrieves a StatusCake Test with a specific name or Test ID
+.EXAMPLE
+   Get-StatusCakeHelperTest
+.INPUTS
+    baseTestURL - Base URL endpoint of the statuscake auth API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    TestName - Name of the test to retrieve
+    TestID - Test ID to retrieve
+.OUTPUTS    
+    Returns the details of the test which exists returning $null if no matching test
+.FUNCTIONALITY
+    Retrieves StatusCake Test via the test name of the test or Test ID
+   
+#>
+function Get-StatusCakeHelperContactGroup
+{
+    [CmdletBinding(PositionalBinding=$false)]    
+    Param(
+        $baseTestURL = "https://app.statuscake.com/API/ContactGroups/",
+        [Parameter(Mandatory=$true)]        
+        $Username,
+        [Parameter(Mandatory=$true)]
+        $ApiKey,
+        [Parameter(ParameterSetName = "Group Name")]
+        [ValidateNotNullOrEmpty()]            
+        [string]$GroupName,
+        [Parameter(ParameterSetName = "Contact ID")]
+        [ValidateNotNullOrEmpty()]            
+        [int]$ContactID        
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+
+    $requestParams = @{
+        uri = $baseTestURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+    }
+
+    $jsonResponse = Invoke-WebRequest @requestParams
+    $response = $jsonResponse | ConvertFrom-Json
+
+    if($GroupName)
+    {
+        $matchingGroups = $response | Where-Object {$_.GroupName -eq $GroupName}
+    }
+    elseif($ContactID)
+    {
+        $matchingGroups = $response | Where-Object {$_.ContactID -eq $ContactID}
+    }
+
+    if($matchingGroups)
+    {
+        Return $matchingGroups
+    }
+    Return $null
+}
+

--- a/StatusCake-Helpers/Public/New-StatusCakeHelperContactGroup.ps1
+++ b/StatusCake-Helpers/Public/New-StatusCakeHelperContactGroup.ps1
@@ -1,0 +1,126 @@
+
+<#
+.Synopsis
+   Create a StatusCake ContactGroup
+.EXAMPLE
+   New-StatusCakeHelperContactGroup -Username "Username" -ApiKey "APIKEY" -GroupName "Example" -email @(test@example.com)
+.INPUTS
+    baseContactGroupURL - Base URL endpoint of the statuscake ContactGroup API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    GroupName - Name of the ContactGroup to be displayed in StatusCake
+
+    <optional parameters>
+    DesktopAlert - Set to 1 To Enable Desktop Alerts
+    Email - Array containing emails addresses to alert.
+    Boxcar - A Boxcar API Key
+    Pushover - A Pushover Account Key
+    PingURL - A URL To Send a POST alert.
+    Mobile - Array containing list of International Format Cell Numbers
+
+.FUNCTIONALITY
+   Creates a new StatusCake ContactGroup using the supplied parameters.
+#>
+function New-StatusCakeHelperContactGroup
+{
+    [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]    
+    Param(
+        $baseContactGroupURL = "https://app.statuscake.com/API/ContactGroups/Update",
+        [Parameter(Mandatory=$true)]        
+        $Username,
+        [Parameter(Mandatory=$true)]        
+        $ApiKey,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()] 
+        $GroupName,
+ 
+        #Optional parameters
+        [ValidateRange(0,1)]         
+        $DesktopAlert,
+        [object]$Email,
+        [ValidatePattern('^((http|https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]                  
+        $PingURL,       
+        [ValidateNotNullOrEmpty()]            
+        [string]$Boxcar,
+        [ValidateNotNullOrEmpty()]         
+        [string]$Pushover,
+        [object]$Mobile
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake ContactGroups") )
+    {
+        $ContactGroupCheck = Get-StatusCakeHelperContactGroup -Username $username -apikey $ApiKey -GroupName $GroupName
+        if($ContactGroupCheck)
+        {
+            Write-Error "ContactGroup with specified name already exists [$ContactGroupCheck]"
+            Return $null 
+        }
+    }
+
+    if($Email)
+    {
+        foreach($emailAddress in $Email)
+        {
+            Write-Verbose "Validating email address [$emailAddress]"
+            if(!$($emailAddress | Test-StatusCakeHelperEmailAddress))
+            {
+                Write-Error "Invalid email address supplied [$emailAddress]"
+                Return $null 
+            }
+        }
+    }
+
+    if($Mobile)
+    {
+        foreach($mobileNumber in $Mobile)
+        {
+            Write-Verbose "Validating mobile number [$mobileNumber]"
+            if(!$($mobileNumber | Test-StatusCakeHelperMobileNumber))
+            {          
+                Write-Error "Mobile number is not in E.164 format [$mobileNumber]"
+                Return $null 
+            }
+        }
+    }    
+
+    $psParams = @{}
+    $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
+    $ParamsToIgnore = @("baseContactGroupURL","Username","ApiKey")
+    foreach ($key in $ParameterList.keys)
+    {
+        $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
+        if($ParamsToIgnore -contains $var.Name)
+        {
+            continue
+        }
+        elseif($var.value -or $var.value -eq 0)
+        {      
+            $psParams.Add($var.name,$var.value)                  
+        }
+    }
+
+    $statusCakeAPIParams = $psParams | ConvertTo-StatusCakeHelperAPIParams
+
+    $putRequestParams = @{
+        uri = $baseContactGroupURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+        method = "Put"
+        ContentType = "application/x-www-form-urlencoded"
+        body = $statusCakeAPIParams 
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Add StatusCake ContactGroup") )
+    {
+        $jsonResponse = Invoke-WebRequest @putRequestParams
+        $response = $jsonResponse | ConvertFrom-Json
+        if($response.Success -ne "True")
+        {
+            Write-Error "$($response.Message) [$($response.Issues)]"
+            Return $null
+        }         
+        Return $response
+    }
+
+}

--- a/StatusCake-Helpers/Public/Remove-StatusCakeHelperContactGroup.ps1
+++ b/StatusCake-Helpers/Public/Remove-StatusCakeHelperContactGroup.ps1
@@ -1,0 +1,96 @@
+
+
+<#
+.Synopsis
+   Removes the specified StatusCake ContactGroup
+.EXAMPLE
+   Remove-StatusCakeHelperContactGroup
+.INPUTS
+    baseContactGroupURL - Base URL endpoint of the statuscake ContactGroup API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    ContactID - ID of the ContactGroup to be removed
+    GroupName - Name of the Contact Group to be removed
+.OUTPUTS    
+    Returns the result of the ContactGroup removal as an object
+.FUNCTIONALITY
+    Removes the StatusCake ContactGroup via it's ContactID or GroupName
+   
+#>
+function Remove-StatusCakeHelperContactGroup
+{
+    [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]
+    Param(
+        $baseContactGroupURL = "https://app.statuscake.com/API/ContactGroups/Update/?ContactID=",
+        [Parameter(Mandatory=$true)]        
+        $Username,
+        [Parameter(Mandatory=$true)]        
+        $ApiKey,
+        [Parameter(ParameterSetName = "ContactID")]
+        [ValidateNotNullOrEmpty()]
+        [int]$ContactID,
+        [Parameter(ParameterSetName = "GroupName")]
+        [ValidateNotNullOrEmpty()]
+        [string]$GroupName,
+        [switch]$Force,        
+        [switch]$PassThru
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+    
+    if($GroupName)
+    {
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake Contact Groups") )
+        {        
+            $ContactGroupCheck = Get-StatusCakeHelperContactGroup -Username $username -apikey $ApiKey -GroupName $GroupName
+            if($ContactGroupCheck)
+            {
+                if($ContactGroupCheck.GetType().Name -eq 'Object[]')
+                {
+                    Write-Error "Multiple ContactGroups found with name [$GroupName]. Please remove the ContactGroup by ContactID"
+                    Return $null            
+                }                  
+                $ContactID = $ContactGroupCheck.ContactID
+            }
+            else 
+            {
+                Write-Error "Unable to find ContactGroup with name [$GroupName]"
+                Return $null
+            }
+        }
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake Tests") )
+    { 
+        $StatusCakeTests = Get-StatusCakeHelperAllTests -Username $username -apikey $ApiKey
+        $StatusCakeTestsWithContact = $StatusCakeTests | Where-Object {$_.ContactGroup -Contains $ContactID}
+        if($StatusCakeTestsWithContact -and !$Force)
+        {
+            Write-Error "ContactGroup in use by tests [$($StatusCakeTestsWithContact.TestID)]. Please use -Force switch to remove this ContactGroup"
+            Return $null            
+        }
+    }  
+
+    $requestParams = @{
+        uri = "$baseContactGroupURL$ContactID"
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+        Method = "Delete"
+    }
+
+    if( $pscmdlet.ShouldProcess("ContactID - $ContactID", "Remove StatusCake ContactGroup") )
+    {
+        $jsonResponse = Invoke-WebRequest @requestParams
+        $response = $jsonResponse | ConvertFrom-Json
+        if($response.Success -ne "True")
+        {
+            Write-Verbose $response
+            Write-Error "$($response.Message) [$($response.Issues)]"
+        }
+        if(!$PassThru)
+        {
+            Return
+        }
+        Return $response        
+    }
+}
+

--- a/StatusCake-Helpers/Public/Remove-StatusCakeHelperTest.ps1
+++ b/StatusCake-Helpers/Public/Remove-StatusCakeHelperTest.ps1
@@ -68,7 +68,7 @@ function Remove-StatusCakeHelperTest
         if($response.Success -ne "True")
         {
             Write-Verbose $response
-            Write-Error "$($response.Message)"
+            Write-Error "$($response.Message) [$($response.Issues)]"
         }
         if(!$PassThru)
         {

--- a/StatusCake-Helpers/Public/Set-StatusCakeHelperContactGroup.ps1
+++ b/StatusCake-Helpers/Public/Set-StatusCakeHelperContactGroup.ps1
@@ -1,0 +1,162 @@
+
+<#
+.Synopsis
+   Set a StatusCake ContactGroup
+.EXAMPLE
+   Set-StatusCakeHelperContactGroup -Username "Username" -ApiKey "APIKEY" -GroupName "Example" -email @(test@example.com)
+.INPUTS
+    baseContactGroupURL - Base URL endpoint of the statuscake ContactGroup API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    ContactID - ID of the contact group to Set
+
+    GroupName - Name of the ContactGroup to be displayed in StatusCake    
+    DesktopAlert - Set to 1 To Enable Desktop Alerts
+    Email - Array containing emails addresses to alert.
+    Boxcar - A Boxcar API Key
+    Pushover - A Pushover Account Key
+    PingURL - A URL To Send a POST alert.
+    Mobile - Array containing list of International Format Cell Numbers
+    SetByGroupName - Flag to set if you wish to Set the Contact Group by Group Name    
+
+.FUNCTIONALITY
+   Sets a StatusCake ContactGroup using the supplied parameters. Values supplied overwrite existing values
+#>
+function Set-StatusCakeHelperContactGroup
+{
+    [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]    
+    Param(     
+        $baseContactGroupURL = "https://app.statuscake.com/API/ContactGroups/Update",
+
+        [Parameter(Mandatory=$true)]           
+        [string]$Username,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ApiKey,       
+
+        [Parameter(ParameterSetName='SetByContactID')]        
+        [int]$ContactID,
+
+        [Parameter(ParameterSetName='SetByGroupName')]        
+        [switch]$SetByGroupName,
+
+        [Parameter(ParameterSetName='SetByGroupName',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByContactID')]          
+        [ValidateNotNullOrEmpty()] 
+        $GroupName,
+
+        [Parameter(ParameterSetName='SetByGroupName')]
+        [Parameter(ParameterSetName='SetByContactID')]         
+        [ValidateRange(0,1)]         
+        $DesktopAlert,
+
+        [Parameter(ParameterSetName='SetByGroupName')]
+        [Parameter(ParameterSetName='SetByContactID')]         
+        [object]$Email,
+
+        [Parameter(ParameterSetName='SetByGroupName')]
+        [Parameter(ParameterSetName='SetByContactID')]         
+        [ValidatePattern('^((http|https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]                  
+        $PingURL,
+        
+        [Parameter(ParameterSetName='SetByGroupName')]
+        [Parameter(ParameterSetName='SetByContactID')]         
+        [ValidateNotNullOrEmpty()]            
+        [string]$Boxcar,
+
+        [Parameter(ParameterSetName='SetByGroupName')]
+        [Parameter(ParameterSetName='SetByContactID')]         
+        [ValidateNotNullOrEmpty()]         
+        [string]$Pushover,
+
+        [Parameter(ParameterSetName='SetByGroupName')]
+        [Parameter(ParameterSetName='SetByContactID')]         
+        [object]$Mobile      
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+
+    if($SetByGroupName -and $GroupName)
+    {
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake ContactGroups"))
+        {            
+            $contactGroupCheck = Get-StatusCakeHelperContactGroup -Username $username -apikey $ApiKey -GroupName $GroupName
+            if(!$contactGroupCheck)
+            {
+                Write-Error "Unable to find Contact Group with specified name [$GroupName]"
+                Return $null  
+            }
+            elseif($contactGroupCheck.GetType().Name -eq 'Object[]')
+            {
+                Write-Error "Multiple Contact Groups with the same name [$GroupName]"
+                Return $null            
+            }
+            $ContactID = $contactGroupCheck.ContactID
+        }
+    }
+
+    if($Email)
+    {
+        foreach($emailAddress in $Email)
+        {
+            Write-Verbose "Validating email address [$emailAddress]"
+            if(!$($emailAddress | Test-StatusCakeHelperEmailAddress))
+            {             
+                Write-Error "Invalid email address supplied [$emailAddress]"
+                Return $null  
+            }
+        }
+    }
+
+    if($Mobile)
+    {
+        foreach($mobileNumber in $Mobile)
+        {
+            Write-Verbose "Validating mobile number [$mobileNumber]"
+            if(!$($mobileNumber | Test-StatusCakeHelperMobileNumber))
+            {      
+                Write-Error "Mobile number is not in E.164 format [$mobileNumber]"
+                Return $null  
+            }
+        }
+    }    
+
+    $psParams = @{}
+    $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
+    $ParamsToIgnore = @("baseContactGroupURL","Username","ApiKey","SetByGroupName")
+    foreach ($key in $ParameterList.keys)
+    {
+        $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
+        if($ParamsToIgnore -contains $var.Name)
+        {
+            continue
+        }
+        elseif($var.value -or $var.value -eq 0)
+        {      
+            $psParams.Add($var.name,$var.value)                  
+        }
+    }
+
+    $statusCakeAPIParams = $psParams | ConvertTo-StatusCakeHelperAPIParams
+
+    $putRequestParams = @{
+        uri = $baseContactGroupURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+        method = "Put"
+        ContentType = "application/x-www-form-urlencoded"
+        body = $statusCakeAPIParams 
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Add StatusCake ContactGroup") )
+    {
+        $jsonResponse = Invoke-WebRequest @putRequestParams
+        $response = $jsonResponse | ConvertFrom-Json
+        if($response.Success -ne "True")
+        {
+            Write-Error "$($response.Message) [$($response.Issues)]"
+            Return $null
+        }         
+        Return $response
+    }
+
+}

--- a/StatusCake-Helpers/Public/Set-StatusCakeHelperTest.ps1
+++ b/StatusCake-Helpers/Public/Set-StatusCakeHelperTest.ps1
@@ -49,80 +49,299 @@ function Set-StatusCakeHelperTest
 {
     [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]    
     Param(
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]        
         $baseTestURL = "https://app.statuscake.com/API/Tests/Update",
+
+        [Parameter(ParameterSetName='SetByTestName',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByTestID',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetNewTest',Mandatory=$true)] 
         [Parameter(Mandatory=$true)]        
         $Username,
+
+        [Parameter(ParameterSetName='SetByTestName',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByTestID',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetNewTest',Mandatory=$true)] 
         [Parameter(Mandatory=$true)]        
         $ApiKey,
-        [Parameter(Mandatory=$true)]        
-        [int]$TestID,
 
-        #Optional parameters
+        [Parameter(ParameterSetName='SetByTestID',Mandatory=$true)]
+        [ValidatePattern('^\d{1,}$')]           
+        $TestID,
+
+        [Parameter(ParameterSetName='SetByTestName',Mandatory=$true)]
+        [switch]$SetByTestName,
+
+        [Parameter(ParameterSetName='SetByTestName',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest',Mandatory=$true)]             
         [ValidateNotNullOrEmpty()] 
         $TestName,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest',Mandatory=$true)]
         [ValidatePattern('^((http|https):\/\/)?([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))*$')]       
         $TestURL,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest',Mandatory=$true)]
         [ValidateRange(0,24000)]        
         $CheckRate,     
-        [ValidateSet("HTTP","TCP","PING")] 
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest',Mandatory=$true)]
+        [ValidateSet("HTTP","TCP","PING","DNS")] 
         [String]$TestType,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidatePattern('^\d{1,}$')]          
         $ContactGroup,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [object]$TestTags,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidatePattern('^\d{2,}$')]             
         $Port,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [object]$NodeLocations,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]        
         [ValidateRange(0,1)]   
         $Paused,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(5,100)] 
         $Timeout,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidatePattern('^((http|https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]           
         $PingURL,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [hashtable]$CustomHeader,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,10)]        
         $Confirmation,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidatePattern('^([a-zA-Z0-9]{2,}\.[a-zA-Z]{2,})(\.[a-zA-Z]{2,})?|^(?!^.*,$)((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))*$')]      
         [string]$DNSServer,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidatePattern('^(?!^.*,$)((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))*$')]          
         [string]$DNSIP,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [string]$BasicUser,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [securestring]$BasicPass,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]     
         $Public,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidatePattern('^((http|https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]      
         $LogoImage,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]         
         $UseJar,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]        
         $Branding,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [string]$WebsiteHost,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]      
         $Virus,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [string]$FindString,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]         
         $DoNotFind,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]         
         $RealBrowser,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,60)]           
         $TriggerRate,     
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [object]$StatusCodes,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]         
         $EnableSSLWarning,
+
+        [Parameter(ParameterSetName='SetByTestName')]
+        [Parameter(ParameterSetName='SetByTestID')]
+        [Parameter(ParameterSetName='SetNewTest')]
         [ValidateRange(0,1)]         
         $FollowRedirect
     )
     $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
 
-    $testCheck = Get-StatusCakeHelperTest -Username $username -apikey $ApiKey -TestID $TestID
-    if(!$testCheck)
+    if($SetByTestName -and $TestName)
+    {   #If setting test by name check if a test or tests with that name exists
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake Tests"))
+        {      
+            $testCheck = Get-StatusCakeHelperTest -Username $username -apikey $ApiKey -TestName $TestName
+            if(!$testCheck)
+            {
+                $result = [PSCustomObject]@{"Success" = "False";"Message" = "No Test with Specified Name Exists";"Data" = $testCheck;"InsertID" = -1}
+                Write-Error "$($result.Message) [$($result.Data)]"
+                Return $null 
+            }
+            elseif($testCheck.GetType().Name -eq 'Object[]')
+            {
+                $result = [PSCustomObject]@{"Success" = "False";"Message" = "Multiple Tests with the same name";"Data" = $testCheck;"InsertID" = -1}
+                Write-Error "$($result.Message) [$($result.Data)]"
+                Return $null          
+            }            
+            $TestID = $testCheck.TestID
+        }
+    }
+    elseif($TestID)
+    {   #If setting by TestID verify that TestID already exists
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake Tests"))
+        {      
+            $testCheck = Get-StatusCakeHelperTest -Username $username -apikey $ApiKey -TestID $TestID
+            if(!$testCheck)
+            {
+                $result = [PSCustomObject]@{"Success" = "False";"Message" = "No Test with Specified ID Exists";"Data" = $testCheck;"InsertID" = -1}
+                Write-Error "$($result.Message) [$($result.Data)]"
+                Return $null 
+            }            
+            $TestID = $testCheck.TestID
+        }
+    }
+    else 
+    {   #Setup a test with the supplied detiails
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake Tests") )
+        {
+            $testCheck = Get-StatusCakeHelperTest -Username $username -apikey $ApiKey -TestName $TestName
+            if($testCheck)
+            {
+                $result = [PSCustomObject]@{"Success" = "False";"Message" = "Test with specified name already exists";"Data" = $testCheck;"InsertID" = -1}
+                Write-Error "$($result.Message) [$($result.Data)]"
+                Return $null 
+            }
+        }        
+    }
+
+    $convertTestURL = $false
+    switch($TestType)
     {
-        $result = [PSCustomObject]@{"Success" = "False";"Message" = "No Test with Specified ID Exists";"Data" = $testCheck;"InsertID" = -1}
-        Return $result
+        "DNS"{
+            If(!$DNSIP)
+            {
+                $result = [PSCustomObject]@{"Success" = "False";"Message" = "No DNSIP supplied for DNS check";"Data" = $testName;"InsertID" = -1}
+                Write-Error "$($result.Message) [$($result.Data)]"
+                Return $null                
+            }
+            $convertTestURL = $true          
+        }        
+        "PING"{$convertTestURL = $true}
+        "TCP"{
+            If(!$Port)
+            {
+                $result = [PSCustomObject]@{"Success" = "False";"Message" = "No Port supplied for TCP check";"Data" = $testName;"InsertID" = -1}
+                Write-Error "$($result.Message) [$($result.Data)]"
+                Return $null                 
+            }
+            $convertTestURL = $true           
+        }        
+        Default{}
+    }
+
+    #Certain test types require only the domain name so remove protocol if it is part of the TestURL
+    if($convertTestURL -and $TestURL)
+    {
+        $TestURL = $TestURL | ConvertTo-StatusCakeHelperDomainName
+    }
+    
+    if($NodeLocations)
+    {
+        foreach($node in $NodeLocations)
+        {
+            Write-Verbose "Validating node location [$node]"
+            if(!$($node | Test-StatusCakeHelperNodeLocation))
+            {
+                Write-Error "Node Location Server code invalid [$node]"
+                Return $null           
+            }
+        }
     }
 
     $psParams = @{}
     $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
-    $ParamsToIgnore = @("baseTestURL","Username","ApiKey")
+    $ParamsToIgnore = @("baseTestURL","Username","ApiKey","SetByTestName")
     foreach ($key in $ParameterList.keys)
     {
         $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
@@ -131,10 +350,10 @@ function Set-StatusCakeHelperTest
             continue
         }
         elseif($var.value -or $var.value -eq 0)
-        {   #Validate Range accepts $true or $false values as 0 or 1 so explictly convert to int for StatusCake API        
+        {        
             $psParams.Add($var.name,$var.value)                  
         }
-    }
+    }     
 
     $statusCakeAPIParams = $psParams | ConvertTo-StatusCakeHelperAPIParams
 
@@ -153,13 +372,14 @@ function Set-StatusCakeHelperTest
         body = $statusCakeAPIParams 
     }
 
-    if( $pscmdlet.ShouldProcess("TestID - $($testCheck.TestID), TestURL - $($testCheck.WebsiteName)", "Update StatusCake Test") )
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Set StatusCake Test") )
     {
         $jsonResponse = Invoke-WebRequest @putRequestParams
         $response = $jsonResponse | ConvertFrom-Json
         if($response.Success -ne "True")
         {
-            Write-Error "$($response.Message)"
+            Write-Error "$($response.Message) [$($response.Issues)]"
+            Return $null
         }        
         Return $response
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # See http://www.appveyor.com/docs/appveyor-yml for many more options
-version: 1.1.{build}
+version: 2.0.{build}
 
 
 #Publish to PowerShell Gallery with the NuGetApiKey
@@ -20,6 +20,11 @@ skip_commits:
 
 build: false
 
+#Build only on the master branch
+branches:
+  only:
+    - master
+    
 #Kick off the CI/CD pipeline
 test_script:
   - ps: . .\build.ps1


### PR DESCRIPTION
New public functions Get-StatusCakeHelperAllContactGroups, Get-StatusCakeHelperContactGroup, New-StatusCakeHelperContactGroup, Remove-StatusCakeHelperContactGroup, Set-StatusCakeHelperContactGroup

New private functions Test-StatusCakeHelperEmailAddress, Test-StatusCakeHelperMobileNumber, Test-StatusCakeHelperNodeLocation, ConvertTo-StatusCakeHelperDomainName

ConvertTo-StatusCakeHelperAPIParams function
Fix typo in comment

New-StatusCakeHelperTest
Standardized the return of the function when an error occurs

Remove-StatusCakeHelperTest
Improve the detail of output when an error occurs

Set-StatusCakeHelperTest
Configure parameter sets to allow setting a test by test name
Update function to make use of  ConvertTo-StatusCakeHelperDomainName function

appveyor.yml
Update YAML to build only on the master branch and incremented version number