### PR TITLE
Update error output of New-StatusCakeHelperTest and Set-StatusCakeHel…

### DIFF
--- a/StatusCake-Helpers/Public/New-StatusCakeHelperTest.ps1
+++ b/StatusCake-Helpers/Public/New-StatusCakeHelperTest.ps1
@@ -118,7 +118,7 @@ function New-StatusCakeHelperTest
         $testCheck = Get-StatusCakeHelperTest -Username $username -apikey $ApiKey -TestName $TestName
         if($testCheck)
         {
-            Write-Error "Test with specified name already exists [$testCheck]"
+            Write-Error "Test with specified name already exists [$TestName] [$($testCheck.TestID)]"
             Return $null 
         }
     }

--- a/StatusCake-Helpers/Public/Set-StatusCakeHelperTest.ps1
+++ b/StatusCake-Helpers/Public/Set-StatusCakeHelperTest.ps1
@@ -259,8 +259,7 @@ function Set-StatusCakeHelperTest
             }
             elseif($testCheck.GetType().Name -eq 'Object[]')
             {
-                $result = [PSCustomObject]@{"Success" = "False";"Message" = "Multiple Tests with the same name";"Data" = $testCheck;"InsertID" = -1}
-                Write-Error "Multiple Tests with the same name [$TestName]"
+                Write-Error "Multiple Tests with the same name [$TestName] [$($testCheck.TestID)]"
                 Return $null          
             }            
             $TestID = $testCheck.TestID
@@ -286,7 +285,7 @@ function Set-StatusCakeHelperTest
             $testCheck = Get-StatusCakeHelperTest -Username $username -apikey $ApiKey -TestName $TestName
             if($testCheck)
             {
-                Write-Error "Test with specified name already exists [$TestName]"
+                Write-Error "Test with specified name already exists [$TestName] [$($testCheck.TestID)]"
                 Return $null 
             }
         }        


### PR DESCRIPTION
…perTest functions

New-StatusCakeHelperTest
Update error output of New-StatusCakeHelperTest function to output more detail when an existing test with the same name is found

Set-StatusCakeHelperTest Function
Update error output of Set-StatusCakeHelperTest function to output more detail when an existing test with the same name is found
Removed unused variable "$result"