### PR TITLE
Add support for SSL Test API features

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,146 @@ New-StatusCakeHelperTest -Username "Username" -ApiKey "APIKEY" -TestName "Exampl
 ```
 ![new-statuscakehelpertest](https://user-images.githubusercontent.com/30263630/29495757-4adfce26-85bd-11e7-8a68-1f8253a91068.PNG)
 
+## Add-StatusCakeHelperTestNodeLocations
+This cmdlet add a Test Node location to a Status Cake Test. The cmdlet checks to see if a test node location is valid by verifying it against the list of server codes retrieved from the StatusCake API before adding it to the test.
+
+```
+Add-StatusCakeHelperTestNodeLocations -Username "Username" -ApiKey "APIKEY" -TestID "123456" -NodeLocations @("EU1","EU2")
+```
+
+## Add-StatusCakeHelperTestStatusCodes
+This cmdlet add a HTTP Status code to a Status Cake Test. The cmdlet checks to see if a HTTP Status Code is valid before adding it to the test.
+
+```
+Add-StatusCakeHelperTestStatusCodes -Username "Username" -ApiKey "APIKEY" -TestID "123456" -StatusCodes @("206","207")
+```
+
+## Add-StatusCakeHelperTestTags
+This cmdlet adds an additional tag to a Status Cake Test.
+
+```
+Add-StatusCakeHelperTestTags -Username "Username" -ApiKey "APIKEY" -TestID "123456" -TestTags @("Tag1","Tag2")
+```
+
+## Remove-StatusCakeHelperTestNodeLocations
+This cmdlet removes a Test Node location from a Status Cake Test. The cmdlet checks to see if a test node location is valid by verifying it against the list of server codes retrieved from the StatusCake API before removing it from the test.
+
+```
+Add-StatusCakeHelperTestNodeLocations -Username "Username" -ApiKey "APIKEY" -TestID "123456" -NodeLocations @("EU1","EU2")
+```
+
+## Remove-StatusCakeHelperTestStatusCodes
+This cmdlet removes a HTTP Status code from a Status Cake Test. The cmdlet checks to see if a HTTP Status Code is valid before removing it from the test.
+
+```
+Remove-StatusCakeHelperTestStatusCodes -Username "Username" -ApiKey "APIKEY" -TestID "123456" -StatusCodes @("206","207")
+```
+
+## Remove-StatusCakeHelperTestTags
+This cmdlet removes a tag from a Status Cake Test.
+
+```
+Remove-StatusCakeHelperTestTags -Username "Username" -ApiKey "APIKEY" -TestID "123456" -TestTags @("Tag1","Tag2")
+```
+
+## Get-StatusCakeHelperAllContactGroups
+This cmdlet retrieves all contact groups.
+
+```
+Get-StatusCakeHelperAllContactGroups -Username "Username" -ApiKey "APIKEY"
+```
+
+## Get-StatusCakeHelperContactGroup
+This cmdlet retrieves a specific contact group.
+
+```
+Get-StatusCakeHelperContactGroup -Username "Username" -ApiKey "APIKEY" -ContactID "123456"
+```
+
+## New-StatusCakeHelperContactGroup
+This cmdlet creates a new contact group. If a mobile number is supplied this is validated to confirm that it meets E.164 number formatting.
+
+```
+New-StatusCakeHelperContactGroup -Username "Username" -ApiKey "APIKEY" -GroupName "Example" -email @(test@example.com) -mobile "+14155552671"
+```
+
+## Remove-StatusCakeHelperContactGroup
+This cmdlet removes a contact group. If the contact group is in use by any tests then the -force switch must be supplied to remove the contact group.
+
+```
+Remove-StatusCakeHelperContactGroup -Username "Username" -ApiKey "APIKEY" -ContactID "123456"
+```
+
+## Get-StatusCakeHelperPausedTests
+This cmdlet retrieves all tests paused longer than the specified time. If no additional parameters specified it returns all tests paused longer than 1 day. Granularity of time can specified down to the minute.
+
+```
+Get-StatusCakeHelperPausedTests -Username "Username" -ApiKey "APIKEY"
+```
+
+## Get-StatusCakeHelperPeriodOfData
+This cmdlet retrieves a list of periods of data for a specified test. A period of data is two time stamps in which status has remained the same - such as a period of downtime or uptime.
+
+```
+Get-StatusCakeHelperPeriodOfData -Username "Username" -ApiKey "APIKEY" -TestID "123456"
+```
+
+## Get-StatusCakeHelperSentAlerts
+This cmdlet retrieves a list of alerts that have been sent. A test ID can be supplied to limit alerts from a single test. Use the "Since" parameter to include results only since that time.
+
+```
+Get-StatusCakeHelperSentAlerts -Username "Username" -ApiKey "APIKEY" -TestID 123456 -since "2017-08-19 13:29:49"
+```
+
+# SSL Tests
+
+## Get-StatusCakeHelperAllSSLTests
+This cmdlet retrieves all SSL Tests
+
+```
+Get-StatusCakeHelperAllSSLTests -Username "Username" -ApiKey "APIKEY"
+```
+
+## Get-StatusCakeHelperSSLTest
+This cmdlet retrieves a specific StatusCake SSL Test by id or domain
+
+```
+Get-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -id 89571
+```
+![new-statuscakehelpertest](https://user-images.githubusercontent.com/30263630/32247953-fb53194c-be7b-11e7-99df-490f892de6c1.png)
+
+## New-StatusCakeHelperSSLTest
+This cmdlet creates a new SSL Test. The cmdlet tests to see if the domain to be monitored already being checked before creating the SSL Test. A SSL test is created by default to have all reminders enabled at 60, 30 and 7 days intervals. Mandatory parameters are illustrated in the example below:
+
+```
+New-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -Domain "https://www.example.com" -checkrate 3600
+```
+
+## Set-StatusCakeHelperSSLTest
+This cmdlet sets the configuration of a specific SSL Test. If a id or a domain with setByDomain flag set is not supplied then a new test will be created
+
+```
+Set-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -id 89571 -checkrate 3600 -Alert_At @("14","90","120") 
+```
+A SSL Test can be updated by domain if there are no duplicates as follows:
+```
+Set-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -Domain "https://www.example.com" -checkrate 3600 -Alert_At @("14","90","120") -SetByDomain
+```
+A new SSL Test can be created via the cmdlet with the following parameters:
+```
+Set-StatusCakeHelperSSLTest @StatusCakeAuth -domain https://www.google.com -CheckRate "3600" -contact_groups "0" -alert_expiry 0 -alert_reminder 0 -alert_broken 0 -Alert_At @("14","90","120")
+```
+
+## Remove-StatusCakeHelperSSLTest
+This cmdlet removes a SSL Test via either id or domain of the SSL Test
+
+```
+Remove-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -id 89571
+```
+To remove by domain specify the domain parameter
+```
+Remove-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -Domain "https://www.example.com"
+```
 
 # Authors
 - Oliver Li

--- a/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperAPIParams.ps1
+++ b/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperAPIParams.ps1
@@ -34,6 +34,14 @@ function ConvertTo-StatusCakeHelperAPIParams
             }
             switch($var.name)
             {
+                "Alert_At"{ #Alert_At need to be supplied as a comma separated list
+                    $value = $var.value -join ","
+                    $outputHashTable.Add($var.name,$value)                                                   
+                }
+                "Contact_Groups"{ #Contact Groups need to be supplied as a comma separated list
+                    $value = $var.value -join ","
+                    $outputHashTable.Add($var.name,$value)
+                }                                
                 "BasicPass"{
                     $outputHashTable.Add($var.name,$var.value)
                     $value = $var.value -replace '.?','*'

--- a/StatusCake-Helpers/Public/Get-StatusCakeHelperSSLTest.ps1
+++ b/StatusCake-Helpers/Public/Get-StatusCakeHelperSSLTest.ps1
@@ -1,0 +1,64 @@
+
+<#
+.Synopsis
+   Gets a StatusCake SSL Test
+.EXAMPLE
+   Get-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -id 123456
+.INPUTS
+    baseSSLTestURL - Base URL endpoint of the statuscake auth API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    Domain - Name of the test to retrieve
+    ID - Test ID to retrieve    
+.OUTPUTS    
+    Returns a StatusCake SSL Tests as an object
+.FUNCTIONALITY
+    Retrieves a specific StatusCake SSL Test
+   
+#>
+function Get-StatusCakeHelperSSLTest
+{
+    [CmdletBinding(PositionalBinding=$false)]    
+    Param(
+        $baseSSLTestURL = "https://app.statuscake.com/API/SSL/",
+        [Parameter(Mandatory=$true)]        
+        $Username,
+        [Parameter(Mandatory=$true)]        
+        $ApiKey,
+
+        [Parameter(ParameterSetName = "Domain")]
+        [ValidatePattern('^((https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]
+        [string]$domain,
+
+        [Parameter(ParameterSetName = "ID")]
+        [ValidateNotNullOrEmpty()]            
+        [int]$id      
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+
+    $requestParams = @{
+        uri = $baseSSLTestURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+    }
+
+    $jsonResponse = Invoke-WebRequest @requestParams
+    $response = $jsonResponse | ConvertFrom-Json
+
+    if($domain)
+    {
+        $matchingTests = $response | Where-Object {$_.domain -eq $domain}
+    }
+    elseif($id)
+    {
+        $matchingTests = $response | Where-Object {$_.id -eq $id}
+    }
+
+    if($matchingTests)
+    {
+        Return $matchingTests
+    }
+
+    Return $null
+}
+

--- a/StatusCake-Helpers/Public/New-StatusCakeHelperSSLTest.ps1
+++ b/StatusCake-Helpers/Public/New-StatusCakeHelperSSLTest.ps1
@@ -1,0 +1,116 @@
+
+<#
+.Synopsis
+   Create a StatusCake SSL Test
+.EXAMPLE
+   New-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -Domain "https://www.example.com" -checkrate 3600
+.INPUTS
+    baseSSLTestURL - Base URL endpoint of the statuscake ContactGroup API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    
+    Domain - URL to check SSL certificate, must begin with https://
+    CheckRate - Checkrate in seconds.
+    Contact_Groups - Array containing contact IDs to alert.
+    Alert_At - Number of days before expiration when reminders will be sent. Defaults to reminders at 60, 30 and 7 days. Must be 3 numeric values.
+    Alert_expiry - 	Set to true to disable expiration alerts.
+    Alert_reminder - Set to true to disable reminder alerts.
+    Alert_broken - Set to true to disable broken alerts
+
+.FUNCTIONALITY
+   Creates a new StatusCake SSL Test using the supplied parameters.
+#>
+function New-StatusCakeHelperSSLTest
+{
+    [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]    
+    Param(
+        $baseSSLTestURL = "https://app.statuscake.com/API/SSL/Update",
+        [Parameter(Mandatory=$true)]        
+        $Username,
+        [Parameter(Mandatory=$true)]        
+        $ApiKey,
+
+        [Parameter(Mandatory=$true)] 
+        [ValidatePattern('^((https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]                  
+        $domain,
+
+        #Contact_Groups must be supplied
+        [ValidateScript({$_ -match '^[\d]+$'})] 
+        [object]$contact_groups="0",
+
+        [Parameter(Mandatory=$true)] 
+        [ValidateSet("300","600","1800","3600","86400","2073600")]
+        $checkrate,
+        
+        [ValidateScript({$_ -match '^[\d]+$'})]        
+        [object]$alert_at=@("7","30","60"),
+
+        [ValidateRange(0,1)] 
+        $alert_expiry=1,
+
+        [ValidateRange(0,1)] 
+        $alert_reminder=1,
+
+        [ValidateRange(0,1)] 
+        $alert_broken=1
+
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+ 
+    if($Alert_At.count -ne 3)
+    {
+        Write-Error "Only three values must be specified for Alert_At parameter"
+        Return
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake SSL Checks") )
+    {
+        $sslTest = Get-StatusCakeHelperSSLTest -Username $username -apikey $ApiKey -domain $domain
+        if($sslTest)
+        {
+            Write-Error "SSL Check with specified domain already exists [$domain] [$($sslTest.id)]"
+            Return $null 
+        }
+    }    
+
+    $psParams = @{}
+    $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
+    $ParamsToIgnore = @("baseSSLTestURL","Username","ApiKey")
+    foreach ($key in $ParameterList.keys)
+    {
+        $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
+        
+        if($ParamsToIgnore -contains $var.Name)
+        {
+            continue
+        }
+        elseif($var.value -or $var.value -eq 0)
+        {   
+            $psParams.Add($var.name,$var.value)                  
+        }
+    }
+
+    $statusCakeAPIParams = $psParams | ConvertTo-StatusCakeHelperAPIParams
+
+    $putRequestParams = @{
+        uri = $baseSSLTestURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+        method = "Put"
+        ContentType = "application/x-www-form-urlencoded"
+        body = $statusCakeAPIParams 
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Add StatusCake SSL Test") )
+    {
+        $jsonResponse = Invoke-WebRequest @putRequestParams
+        $response = $jsonResponse | ConvertFrom-Json
+        if($response.Success -ne "True")
+        {
+            Write-Error "$($response.Message) [$($response.Issues)]"
+            Return $null
+        }         
+        Return $response
+    }
+
+}

--- a/StatusCake-Helpers/Public/Remove-StatusCakeHelperSSLTest.ps1
+++ b/StatusCake-Helpers/Public/Remove-StatusCakeHelperSSLTest.ps1
@@ -1,0 +1,102 @@
+
+<#
+.Synopsis
+   Remove a StatusCake SSL Test
+.EXAMPLE
+   Remove-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -ID 123456
+.INPUTS
+    baseSSLTestURL - Base URL endpoint of the statuscake ContactGroup API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    
+    ID - ID of the SSL Test to remove
+
+.FUNCTIONALITY
+   Deletes a StatusCake SSL Test using the supplied ID.
+#>
+function Remove-StatusCakeHelperSSLTest
+{
+    [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]    
+    Param(
+        $baseSSLTestURL = "https://app.statuscake.com/API/SSL/Update",
+
+        [Parameter(Mandatory=$true)]        
+        $Username,        
+
+        [Parameter(Mandatory=$true)]        
+        $ApiKey,
+
+        [Parameter(ParameterSetName = "ID")]             
+        [int]$id,
+
+        [Parameter(ParameterSetName = "Domain")]
+        [ValidatePattern('^((https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]                 
+        [string]$domain,        
+
+        [switch]$PassThru        
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+ 
+    if($domain)
+    {
+        $sslTest = Get-StatusCakeHelperSSLTest -Username $username -apikey $ApiKey -domain $domain
+        if($sslTest)
+        {
+            if($sslTest.GetType().Name -eq 'Object[]')
+            {
+                Write-Error "Multiple SSL Tests found with domain [$domain]. Please remove the SSL test by ID"
+                Return $null            
+            }
+            $id = $sslTest.id
+        }
+        else 
+        {
+            Write-Error "Unable to find SSL Test with name [$domain]"
+            Return $null
+        }
+    }
+
+    $psParams = @{}
+    $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
+    $ParamsToIgnore = @("baseSSLTestURL","Username","ApiKey","domain")
+    foreach ($key in $ParameterList.keys)
+    {
+        $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
+        if($ParamsToIgnore -contains $var.Name)
+        {
+            continue
+        }
+        elseif($var.value -or $var.value -eq 0)
+        {   #Contact_Groups can be empty string but must be supplied
+            $psParams.Add($var.name,$var.value)                  
+        }
+    }
+
+    $statusCakeAPIParams = $psParams | ConvertTo-StatusCakeHelperAPIParams
+
+    $putRequestParams = @{
+        uri = $baseSSLTestURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+        method = "Delete"
+        ContentType = "application/x-www-form-urlencoded"
+        body = $statusCakeAPIParams 
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Remove StatusCake SSL Test") )
+    {
+        $jsonResponse = Invoke-WebRequest @putRequestParams
+        $response = $jsonResponse | ConvertFrom-Json
+        if($response.Success -ne "True")
+        {
+            Write-Verbose $response
+            Write-Error "$($response.Message) [$($response.Issues)]"
+        }         
+        if(!$PassThru)
+        {
+            Return
+        }
+        Return $response     
+    }
+
+}

--- a/StatusCake-Helpers/Public/Set-StatusCakeHelperSSLTest.ps1
+++ b/StatusCake-Helpers/Public/Set-StatusCakeHelperSSLTest.ps1
@@ -1,0 +1,182 @@
+
+<#
+.Synopsis
+   Updates a StatusCake SSL Test
+.EXAMPLE
+   Set-StatusCakeHelperSSLTest -Username "Username" -ApiKey "APIKEY" -id 123456 -checkrate 3600
+.INPUTS
+    baseSSLTestURL - Base URL endpoint of the statuscake ContactGroup API
+    Username - Username associated with the API key
+    ApiKey - APIKey to access the StatusCake API
+    
+    Domain - URL to check SSL certificate, must begin with https://
+    CheckRate - Checkrate in seconds.
+    Contact_Groups - Array containing contact IDs to alert.
+    Alert_At - Number of days before expiration when reminders will be sent. Must be 3 numeric values.
+    Alert_Expiry - 	Set to true to enable expiration alerts.
+    Alert_Reminder - Set to true to enable reminder alerts.
+    Alert_Broken - Set to true to enable broken alerts
+
+.FUNCTIONALITY
+   Creates a new StatusCake SSL Test using the supplied parameters.
+#>
+function Set-StatusCakeHelperSSLTest
+{
+    [CmdletBinding(PositionalBinding=$false,SupportsShouldProcess=$true)]    
+    Param(
+        #[Parameter(ParameterSetName='SetByDomain',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]
+        [Parameter(ParameterSetName='NewSSLTest')]          
+        $baseSSLTestURL = "https://app.statuscake.com/API/SSL/Update",
+
+        [Parameter(ParameterSetName='SetByID',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByDomain',Mandatory=$true)]        
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)] 
+        $Username,
+
+        [Parameter(ParameterSetName='SetByID',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByDomain',Mandatory=$true)]        
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)] 
+        $ApiKey,
+
+        [Parameter(ParameterSetName='SetByID',Mandatory=$true)]
+        $id,
+
+        [Parameter(ParameterSetName='SetByDomain',Mandatory=$true)]
+        [switch]$SetByDomain,        
+
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [ValidatePattern('^((https):\/\/)([a-zA-Z0-9\-]+(\.[a-zA-Z]+)+.*)$|^(?!^.*,$)')]                  
+        $domain,
+
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]    
+        [ValidateScript({$_ -match '^[\d]+$'})] 
+        [object]$contact_groups,
+
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]   
+        [ValidateSet("300","600","1800","3600","86400","2073600")]
+        $checkrate,
+
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]   
+        [ValidateScript({$_ -match '^[\d]+$'})]        
+        [object]$alert_at,
+        
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]           
+        [ValidateRange(0,1)]
+        $alert_expiry,
+      
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]           
+        [ValidateRange(0,1)]
+        $alert_reminder,
+
+        [Parameter(ParameterSetName='SetByID')]
+        [Parameter(ParameterSetName='SetByDomain')]          
+        [Parameter(ParameterSetName='NewSSLTest',Mandatory=$true)]   
+        [ValidateRange(0,1)]
+        $alert_broken
+
+    )
+    $authenticationHeader = @{"Username"="$username";"API"="$ApiKey"}
+ 
+    if($Alert_At -and $Alert_At.count -ne 3)
+    {
+        Write-Error "Only three values must be specified for Alert_At parameter"
+        Return
+    }
+
+    if($SetByDomain -and $Domain)
+    {   #If setting test by domain verify if a test or tests with that name exists
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake SSL tests"))
+        {      
+            $sslTest = Get-StatusCakeHelperSSLTest -Username $username -apikey $ApiKey -Domain $Domain
+            if(!$sslTest)
+            {
+                Write-Error "No SSL test with Specified Domain Exists [$Domain]"
+                Return $null 
+            }
+            elseif($sslTest.GetType().Name -eq 'Object[]')
+            {
+                Write-Error "Multiple SSL tests with the same name [$Domain] [$($sslTest.id)]"
+                Return $null          
+            }            
+            $id = $sslTest.id
+        }
+    }
+    elseif($id)
+    {   #If setting by id verify that id already exists
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake SSL tests"))
+        {      
+            $sslTest = Get-StatusCakeHelperSSLTest -Username $username -apikey $ApiKey -id $id
+            if(!$sslTest)
+            {
+                Write-Error "No SSL test with Specified ID Exists [$id]"
+                Return $null 
+            }            
+            $id = $sslTest.id
+        }
+    }
+    else 
+    {   #Setup a test with the supplied detiails
+        if( $pscmdlet.ShouldProcess("StatusCake API", "Retrieve StatusCake SSL tests") )
+        {
+            $sslTest = Get-StatusCakeHelperSSLTest -Username $username -apikey $ApiKey -Domain $Domain
+            if($sslTest)
+            {
+                Write-Error "SSL test with specified name already exists [$Domain] [$($sslTest.id)]"
+                Return $null 
+            }
+        }        
+    }
+
+    $psParams = @{}
+    $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
+    $ParamsToIgnore = @("baseSSLTestURL","Username","ApiKey")
+    foreach ($key in $ParameterList.keys)
+    {
+        $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
+        if($ParamsToIgnore -contains $var.Name)
+        {
+            continue
+        }
+        elseif($var.value -or $var.value -eq 0)
+        {   #Contact_Groups can be empty string but must be supplied
+            $psParams.Add($var.name,$var.value)                  
+        }
+    }
+
+    $statusCakeAPIParams = $psParams | ConvertTo-StatusCakeHelperAPIParams
+
+    $putRequestParams = @{
+        uri = $baseSSLTestURL
+        Headers = $authenticationHeader
+        UseBasicParsing = $true
+        method = "Put"
+        ContentType = "application/x-www-form-urlencoded"
+        body = $statusCakeAPIParams 
+    }
+
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Set StatusCake SSL Test") )
+    {
+        $jsonResponse = Invoke-WebRequest @putRequestParams
+        $response = $jsonResponse | ConvertFrom-Json
+        if($response.Success -ne "True")
+        {
+            Write-Error "$($response.Message) [$($response.Issues)]"
+            Return $null
+        }         
+        Return $response
+    }
+
+}


### PR DESCRIPTION
Update readme.md to document new functions

Update ConvertTo-StatusCakeHelperAPIParams to support converting Alert_At and Contact_Groups parameters to csv values

Add following new functions

Get-StatusCakeHelperSSLTest
New-StatusCakeHelperSSLTest
Set-StatusCakeHelperSSLTest
Remove-StatusCakeHelperSSLTest