### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StatusCake-Helpers [![Build status](https://dev.azure.com/oliverli0875/Helpers/_apis/build/status/Oliver-Lii.statuscake-helpers?branchName=master)](https://ci.appveyor.com/project/Oliver-Lii/statuscake-helpers/branch/master) [![GitHub license](https://img.shields.io/github/license/Oliver-Lii/StatusCake-Helpers.svg)](LICENSE) [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/StatusCake-Helpers.svg)]()
+# StatusCake-Helpers [![Build status](https://dev.azure.com/oliverli0875/Helpers/_apis/build/status/Oliver-Lii.statuscake-helpers?branchName=master)](https://dev.azure.com/oliverli0875/Helpers/_build?definitionId=1&_a=summary&repositoryFilter=1&branchFilter=2) [![GitHub license](https://img.shields.io/github/license/Oliver-Lii/StatusCake-Helpers.svg)](LICENSE) [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/StatusCake-Helpers.svg)]()
 
 
 This module was written to support interaction with the Statuscake API via Powershell. Additional functionality may be added later and I will use this as a generic module to house Powershell functions specific to interacting with the Statuscake API.


### PR DESCRIPTION
Modify build status badge hyperlink to point to Azure DevOps Pipeline instead of Appveyor which is no longer used