### PR TITLE
build.psake.ps1

### DIFF
--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -233,31 +233,11 @@ Task 'CreateBuildArtifact' -Depends 'Init' {
 Task 'PublishToPSGallery' -Depends 'Test' {
     $lines
 
-    $Params = @{
-        Path    = "$StagingModulePath"
-        Force   = $true
-        Recurse = $false
+    $publishParams = @{
+        Path        = $StagingModulePath
+        NugetApiKey = $env:NugetApiKey
+        Force       = $true
+        Verbose     = $true
     }
-    Invoke-PSDeploy @Verbose @Params
+    Publish-Module @publishParams
 }
-
-#region NOT USED FOR THIS DEMO
-# Task 'Release' -Depends 'Clean', 'Test', 'UpdateDocumentation', 'CombineFunctionsAndStage', 'CreateBuildArtifact' #'UpdateManifest', 'UpdateTag'
-Task 'Build' -Depends 'Init' {
-    $lines
-
-    # Load the module, read the exported functions, update the psd1 FunctionsToExport
-    Set-ModuleFunctions -Name $env:BHPSModuleManifest
-
-    # Bump the module version
-    try {
-        $Version = Get-NextPSGalleryVersion -Name $env:BHProjectName -ErrorAction 'Stop'
-        Update-Metadata -Path $env:BHPSModuleManifest -PropertyName 'ModuleVersion' -Value $Version -ErrorAction 'Stop'
-    } catch {
-        "Failed to update version for '$env:BHProjectName': $_.`nContinuing with existing version"
-    }
-}
-
-
-
-#endregion NOT USED FOR THIS DEMO

--- a/Tests/Unit/StatusCake.tests.ps1
+++ b/Tests/Unit/StatusCake.tests.ps1
@@ -4,17 +4,15 @@ Param(
     [ValidateNotNullOrEmpty()]
     [string]$StatusCakeAPIKey = $env:StatusCake_API_Key
 )
-Remove-Module $env:BHPROJECTNAME -ErrorAction SilentlyContinue
 
 Describe 'StatusCake Module Tests' {
 
     It "Module statuscake-helpers imports without throwing an exception" {
+        Remove-Module $env:BHPROJECTNAME -ErrorAction SilentlyContinue
         {Import-Module $env:BHPSModuleManifest -Force } | Should -Not -Throw
     }
 
 }
-
-Import-Module $env:BHPSModuleManifest -Force
 
 if(! (Test-StatusCakeHelperAPIAuthSet))
 {


### PR DESCRIPTION
* Change task PublishToPSGallery to use Publish-Module to avoid duplicate Pester test run when using Invoke-PSDeploy
* Remove unused task Build

StatusCake.test.ps1
Describe 'StatusCake Module Tests'
It "Module statuscake-helpers imports without throwing an exception"
* Include command to remove module as part of Pester Module importing test