### PR TITLE
Fix bug with updating maintenance window

### DIFF
--- a/StatusCake-Helpers/Public/MaintenanceWindows/Clear-StatusCakeHelperMaintenanceWindow.ps1
+++ b/StatusCake-Helpers/Public/MaintenanceWindows/Clear-StatusCakeHelperMaintenanceWindow.ps1
@@ -85,31 +85,16 @@ function Clear-StatusCakeHelperMaintenanceWindow
         }
     }
 
-    $exclude = @("Name")
-    $clear = @()
-    if($TestIDs){$clear += "raw_tests"}
-    if($TestTags){$clear += "raw_tags"}
+    $clearItems = @{}
+    if($TestIDs){$clearItems["raw_tests"]=@()}
+    if($TestTags){$clearItems["raw_tags"]=""}
 
-    $allParameterValues = $MyInvocation | Get-StatusCakeHelperParameterValue -BoundParameters $PSBoundParameters
-    $statusCakeAPIParams = $allParameterValues | Get-StatusCakeHelperAPIParameter -InvocationInfo $MyInvocation -Exclude $exclude -Clear $clear
-    $statusCakeAPIParams = $statusCakeAPIParams | ConvertTo-StatusCakeHelperAPIParameter
-
-    $requestParams = @{
-        uri = "https://app.statuscake.com/API/Maintenance/Update"
-        Headers = @{"Username"=$APICredential.Username;"API"=$APICredential.GetNetworkCredential().password}
-        UseBasicParsing = $true
-        method = "Post"
-        ContentType = "application/x-www-form-urlencoded"
-        body = $statusCakeAPIParams
-    }
-
-    if( $pscmdlet.ShouldProcess("StatusCake API", "Set StatusCake Maintenance Window") )
+    if( $pscmdlet.ShouldProcess("StatusCake API", "Clear Value From StatusCake Test"))
     {
-        $response = Invoke-RestMethod @requestParams
-        $requestParams=@{}
-        if($response.Success -ne "True")
+        $result = Update-StatusCakeHelperMaintenanceWindow -APICredential $APICredential -ID $ID @clearItems
+        if($PassThru)
         {
-            Write-Error "$($response.Message) [$($response.Issues)]"
+            Return $result
         }
     }
 }

--- a/StatusCake-Helpers/Public/MaintenanceWindows/Update-StatusCakeHelperMaintenanceWindow.ps1
+++ b/StatusCake-Helpers/Public/MaintenanceWindows/Update-StatusCakeHelperMaintenanceWindow.ps1
@@ -37,7 +37,7 @@ function Update-StatusCakeHelperMaintenanceWindow
 
         [Parameter(ParameterSetName='SetByID',Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
-        [string]$ID,
+        [int]$ID,
 
         [Parameter(ParameterSetName='SetByName',Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -113,7 +113,17 @@ function Update-StatusCakeHelperMaintenanceWindow
     }
 
     $exclude = @("Name")
-    $lower = @("Timezone","Name")
+    $lower = @("Timezone","Name","ID")
+    # Start and end date need to be sent on edit
+    if(!$StartDate)
+    {
+        $StartDate = $maintenanceWindow.start_utc
+    }
+    if(!$EndDate)
+    {
+        $EndDate = $maintenanceWindow.end_utc
+    }
+
     $allParameterValues = $MyInvocation | Get-StatusCakeHelperParameterValue -BoundParameters $PSBoundParameters
     $statusCakeAPIParams = $allParameterValues | Get-StatusCakeHelperAPIParameter -InvocationInfo $MyInvocation -Exclude $exclude -ToLowerName $lower
     $statusCakeAPIParams = $statusCakeAPIParams | ConvertTo-StatusCakeHelperAPIParameter

--- a/Tests/Unit/StatusCake.tests.ps1
+++ b/Tests/Unit/StatusCake.tests.ps1
@@ -273,12 +273,12 @@ Describe "StatusCake Maintenance Windows" {
         $results.count | Should -BeGreaterThan 0
     }
 
-    It "Update-StatusCakeHelperMaintenanceWindow updates the maintenance window" -Skip{
+    It "Update-StatusCakeHelperMaintenanceWindow updates the maintenance window"{
         $result = Update-StatusCakeHelperMaintenanceWindow -ID $SCMWTest.id -RecurEvery 30
-        $result.Success | Should Be "True"
+        $result.recur_every | Should Be 30
     }
 
-    It "Clear-StatusCakeHelperMaintenanceWindow clears a test associated with a maintenance window" -Skip{
+    It "Clear-StatusCakeHelperMaintenanceWindow clears a test associated with a maintenance window"{
         Clear-StatusCakeHelperMaintenanceWindow -ID $SCMWTest.id -TestIDs
         $results = Get-StatusCakeHelperMaintenanceWindow -ID $SCMWTest.id
         $results.raw_tests | Should -BeFalse


### PR DESCRIPTION
Clear-StatusCakeHelperMaintenanceWindow
* Use Update-StatusCakeHelperMaintenanceWindow function to edit existing maintenance window

Update-StatusCakeHelperMaintenanceWindow
* Fix incorrect variable type for ID parameter
* Ensure ID parameter is sent in lowercase
* Add start and end parameters to REST call required for editing a maintenance window

Pester Tests

* Re-enable "Update-StatusCakeHelperMaintenanceWindow updates the maintenance window" test
* Re-enable "Clear-StatusCakeHelperMaintenanceWindow clears a test associated with a maintenance window" test