### PR TITLE
Update pipeline task to use supported NuGet Authenticate task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
         inputs:
           versionSpec: 5.4.0
 
-      - task: NuGetAuthenticate@0
+      - task: NuGetAuthenticate@1
         displayName: 'NuGet Authenticate'
 
       - powershell: |


### PR DESCRIPTION
Update pipeline to use NuGet Authenticate v1 task instead of deprecated task.