### PR TITLE
Feature/add after query parameter

### DIFF
--- a/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperAPIValue.ps1
+++ b/StatusCake-Helpers/Private/ConvertTo-StatusCakeHelperAPIValue.ps1
@@ -48,7 +48,7 @@ function ConvertTo-StatusCakeHelperAPIValue
                 'DateTime'{ #Dates needs to be in RFC3339 unless Unix timestamp has been specified for the parameter
                     if($name -in $DateUnix)
                     {
-                        $value = [int64]($var.value).ToUniversalTime() | Get-Date -UFormat %s
+                        [int64]$value = ($var.value).ToUniversalTime() | Get-Date -UFormat %s
                     }
                     else
                     {

--- a/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeAlert.ps1
+++ b/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeAlert.ps1
@@ -14,6 +14,8 @@
     Name of the Test to retrieve the sent alerts for
 .PARAMETER Before
     Return only results from before this date
+.PARAMETER After
+    Return only results after this date
 .PARAMETER Limit
     The maximum of number of results to return
 .OUTPUTS
@@ -48,6 +50,9 @@ function Get-StatusCakeHelperUptimeAlert
         [datetime]$Before,
 
         [ValidateNotNullOrEmpty()]
+        [datetime]$After,
+
+        [ValidateNotNullOrEmpty()]
         [int]$Limit
     )
 
@@ -65,11 +70,8 @@ function Get-StatusCakeHelperUptimeAlert
         ID = $ID
     }
 
-    if($Before)
-    {
-        $parameter = $Before | ConvertTo-StatusCakeHelperAPIValue -DateUnix @("Before")
-        $metaDataParameters["Parameter"] = $parameter
-    }
+    $allParameterValues = $MyInvocation | Get-StatusCakeHelperParameterValue -BoundParameters $PSBoundParameters
+    $metaDataParameters["Parameter"] = $allParameterValues | Get-StatusCakeHelperAPIParameter -InvocationInfo $MyInvocation -Exclude @("Limit") | ConvertTo-StatusCakeHelperAPIValue -DateUnix @("Before","After")
 
     if($Limit)
     {

--- a/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeAlert.ps1
+++ b/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeAlert.ps1
@@ -3,29 +3,35 @@
 .SYNOPSIS
     Returns a list of uptime check alerts for a test
 .DESCRIPTION
-    Returns all alerts that have been sent for a test by its name or id. The return order is newest alerts are shown first.
-    Alerts to be returned can be filtered by date using the Before parameter. The number of alerts returned can be controlled
+    Returns all alerts that have been triggered for a test by its name or id. The return order is newest alerts are shown first.
+    Alerts to be returned can be filtered by date using the After/Before parameters. The number of alerts returned can be controlled
     using the Limit argument.
 .PARAMETER APICredential
     Credentials to access StatusCake API
 .PARAMETER ID
-    ID of the Test to retrieve the sent alerts for
+    ID of the Test to retrieve the triggered alerts for
 .PARAMETER Name
-    Name of the Test to retrieve the sent alerts for
+    Name of the Test to retrieve the triggered alerts for
 .PARAMETER Before
-    Return only results from before this date
+    Return only alerts triggered before this date
 .PARAMETER After
-    Return only results after this date
+    Return only alerts triggered after this date
 .PARAMETER Limit
     The maximum of number of results to return
 .OUTPUTS
-    Returns an object with the details on the Alerts Sent
+    Returns an object with the details on the alerts triggered
 .EXAMPLE
     C:\PS> Get-StatusCakeHelperUptimeAlert -ID 123456 -Before "2017-08-19 13:29:49"
-    Return all the alerts sent for test ID 123456 since the 19th August 2017 13:29:49
+    Return all the alerts triggered for test ID 123456 since the 19th August 2017 13:29:49
+.EXAMPLE
+    C:\PS> Get-StatusCakeHelperUptimeAlert -ID 123456 -After "2018-01-01 00:00:00" -Before "2019-01-01 00:00:00"
+    Return all the alerts triggered for test ID 123456 after the 1st January 2018 but before 1st January 2019
 .EXAMPLE
     C:\PS> Get-StatusCakeHelperUptimeAlert -ID 123456 -Limit 100
-    Return the last 100 alerts sent for test ID 123456
+    Return the last 100 alerts triggered for test ID 123456
+.EXAMPLE
+    C:\PS> Get-StatusCakeHelperUptimeAlert -ID 123456 -Limit 1
+    Return the most recent alert triggered for test ID 123456
 .LINK
     https://github.com/Oliver-Lii/statuscake-helpers/blob/master/Documentation/Uptime/Base/Get-StatusCakeHelperUptimeAlert.md
 .LINK

--- a/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeHistory.ps1
+++ b/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeHistory.ps1
@@ -3,28 +3,31 @@
 .SYNOPSIS
     Returns uptime check history results for tests
 .DESCRIPTION
-    Returns uptime check history results for tests detailing the runs performed on the StatusCake testing infrastructure. The return order is newest alerts are shown first.
-    Alerts to be returned can be filtered by date using the Before parameter.
+    Returns uptime check history results for tests detailing the runs performed on the StatusCake testing infrastructure. The most recent history results are shown first.
+    Alerts to be returned can be filtered by date using the After/Before parameters.
 .PARAMETER APICredential
     Credentials to access StatusCake API
 .PARAMETER ID
-    ID of the Test to retrieve the sent alerts for
+    ID of the Test to retrieve the history results for
 .PARAMETER Name
-    Name of the Test to retrieve the sent alerts for
+    Name of the Test to retrieve the history results for
 .PARAMETER Before
-    Return only results from before this date
+    Return only history results created before this date
 .PARAMETER After
-    Return only results after this date
+    Return only history results created after this date
 .PARAMETER Limit
     The maximum of number of results to return
 .OUTPUTS
-    Returns an object with the details on the Alerts Sent
+    Returns an object with the details from a StatusCake test run
 .EXAMPLE
     C:\PS> Get-StatusCakeHelperUptimeHistory -ID 123456 -Before "2017-08-19 13:29:49"
     Return all the uptime history for test ID 123456 since the 19th August 2017 13:29:49
 .EXAMPLE
     C:\PS> Get-StatusCakeHelperUptimeHistory -ID 123456 -Limit 100
-    Return the last 100 historical results sent for test ID 123456
+    Return the last 100 historical results for test ID 123456
+.EXAMPLE
+    C:\PS> Get-StatusCakeHelperUptimeHistory -ID 123456 -Limit 1
+    Return the most recent historical result for test ID 123456
 .LINK
     https://github.com/Oliver-Lii/statuscake-helpers/blob/master/Documentation/Uptime/Property/Get-StatusCakeHelperUptimeHistory.md
 .LINK

--- a/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeHistory.ps1
+++ b/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimeHistory.ps1
@@ -13,6 +13,8 @@
     Name of the Test to retrieve the sent alerts for
 .PARAMETER Before
     Return only results from before this date
+.PARAMETER After
+    Return only results after this date
 .PARAMETER Limit
     The maximum of number of results to return
 .OUTPUTS
@@ -46,6 +48,9 @@ function Get-StatusCakeHelperUptimeHistory
         [ValidateNotNullOrEmpty()]
         [datetime]$Before,
 
+        [ValidateNotNullOrEmpty()]
+        [datetime]$After,
+
         [int]$Limit
     )
 
@@ -63,11 +68,8 @@ function Get-StatusCakeHelperUptimeHistory
         ID = $ID
     }
 
-    if($Before)
-    {
-        $parameter = $Before | ConvertTo-StatusCakeHelperAPIValue -DateUnix @("Before")
-        $metaDataParameters["Parameter"] = $parameter
-    }
+    $allParameterValues = $MyInvocation | Get-StatusCakeHelperParameterValue -BoundParameters $PSBoundParameters
+    $metaDataParameters["Parameter"] = $allParameterValues | Get-StatusCakeHelperAPIParameter -InvocationInfo $MyInvocation -Exclude @("Limit") | ConvertTo-StatusCakeHelperAPIValue -DateUnix @("Before","After")
 
     if($Limit)
     {

--- a/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimePeriod.ps1
+++ b/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimePeriod.ps1
@@ -12,6 +12,8 @@
     Name of the Test to retrieve the sent alerts for
 .PARAMETER Before
     Return only results from before this date
+.PARAMETER After
+    Return only results after this date
 .PARAMETER Limit
     The maximum of number of results to return
 .OUTPUTS
@@ -45,6 +47,9 @@ function Get-StatusCakeHelperUptimePeriod
         [ValidateNotNullOrEmpty()]
         [datetime]$Before,
 
+        [ValidateNotNullOrEmpty()]
+        [datetime]$After,
+
         [int]$Limit
     )
 
@@ -62,11 +67,8 @@ function Get-StatusCakeHelperUptimePeriod
         ID = $ID
     }
 
-    if($Before)
-    {
-        $parameter = $Before | ConvertTo-StatusCakeHelperAPIValue -DateUnix @("Before")
-        $metaDataParameters["Parameter"] = $parameter
-    }
+    $allParameterValues = $MyInvocation | Get-StatusCakeHelperParameterValue -BoundParameters $PSBoundParameters
+    $metaDataParameters["Parameter"] = $allParameterValues | Get-StatusCakeHelperAPIParameter -InvocationInfo $MyInvocation -Exclude @("Limit") | ConvertTo-StatusCakeHelperAPIValue -DateUnix @("Before","After")
 
     if($Limit)
     {

--- a/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimePeriod.ps1
+++ b/StatusCake-Helpers/Public/Uptime/Metadata/Get-StatusCakeHelperUptimePeriod.ps1
@@ -7,23 +7,29 @@
 .PARAMETER APICredential
     Credentials to access StatusCake API
 .PARAMETER ID
-    ID of the Test to retrieve the sent alerts for
+    ID of the Test to retrieve the uptime check periods for
 .PARAMETER Name
-    Name of the Test to retrieve the sent alerts for
+    Name of the Test to retrieve the uptime check periods for
 .PARAMETER Before
-    Return only results from before this date
+    Return only check periods created before this date
 .PARAMETER After
-    Return only results after this date
+    Return only check periods created after this date
 .PARAMETER Limit
     The maximum of number of results to return
 .OUTPUTS
-    Returns an object with the details on the Alerts Sent
+    Returns an object with the details of the uptime check periods
 .EXAMPLE
     C:\PS> Get-StatusCakeHelperUptimePeriod -TestID 123456 -Before "2017-08-19 13:29:49"
     Return all the alerts sent for test ID 123456 since the 19th August 2017 13:29:49
 .EXAMPLE
+    C:\PS> Get-StatusCakeHelperUptimePeriod -ID 123456 -After "2018-01-01 00:00:00" -Before "2019-01-01 00:00:00"
+    Return all the uptime check periods for test ID 123456 created after the 1st January 2018 but before 1st January 2019
+.EXAMPLE
     C:\PS> Get-StatusCakeHelperUptimePeriod -ID 123456 -Limit 100
     Return the last 100 uptime check periods sent for test ID 123456
+.EXAMPLE
+    C:\PS> Get-StatusCakeHelperUptimePeriod -ID 123456 -Limit 1
+    Return the most recent uptime check period sent for test ID 123456
 .LINK
     https://github.com/Oliver-Lii/statuscake-helpers/blob/master/Documentation/Uptime/Property/Get-StatusCakeHelperUptimePeriod.md
 .LINK

--- a/Tests/Unit/StatusCake.Uptime.tests.ps1
+++ b/Tests/Unit/StatusCake.Uptime.tests.ps1
@@ -77,16 +77,37 @@ Describe "StatusCake Uptime Tests" {
         $result.count | Should -BeLessOrEqual 150
     }
 
+    It "Get-StatusCakeHelperUptimeAlert retrieves alerts triggered only in 2022"{
+        $result = Get-StatusCakeHelperUptimeAlert -ID 5084968 -After "2022-01-01T00:00:00+00:00" -Before "2023-01-01T00:00:00+00:00"
+        $year = $result.triggered_at | Get-Date -Format yyyy | Sort-Object -Unique
+        $year | Should -Be 2022
+        $year.count | Should -Be 1
+    }
+
     It "Get-StatusCakeHelperUptimeHistory no more than 150 items of uptime test history"{
         $result = Get-StatusCakeHelperUptimeHistory -ID 3022884 -Limit 150
         $result.count | Should -BeGreaterOrEqual 2
         $result.count | Should -BeLessOrEqual 150
     }
 
+    It "Get-StatusCakeHelperUptimeHistory retrieves history only from 2022" -skip{
+        $result = Get-StatusCakeHelperUptimeHistory -ID 3022884 -After "2022-01-01T00:00:00+00:00" -Before "2023-01-01T00:00:00+00:00"
+        $year = $result.created_at | Get-Date -Format yyyy | Sort-Object -Unique
+        $year | Should -Be 2022
+        $year.count | Should -Be 1
+    }
+
     It "Get-StatusCakeHelperUptimePeriod retrieves no more than 150 uptime check periods"{
         $result = Get-StatusCakeHelperUptimePeriod -ID 3022884 -Limit 150
         $result.count | Should -BeGreaterOrEqual 2
         $result.count | Should -BeLessOrEqual 150
+    }
+
+    It "Get-StatusCakeHelperUptimePeriod retrieves check periods only from 2022"{
+        $result = Get-StatusCakeHelperUptimePeriod -ID 5084968 -After "2022-01-01T00:00:00+00:00" -Before "2023-01-01T00:00:00+00:00"
+        $year = $result.created_at | Get-Date -Format yyyy | Sort-Object -Unique
+        $year | Should -Be 2022
+        $year.count | Should -Be 1
     }
 
     It "Remove-StatusCakeHelperUptimeTest removes a test by ID"{


### PR DESCRIPTION
Fix issue where uptime metadata functions did not filter results when using the "Before" parameter as the Date was not being cast correctly.
Support the use of the "After" API parameter
Add Pester tests for uptime metadata functions using the After and Before parameters
Add additional examples of usage

